### PR TITLE
Object storage API and sample implementation

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"google.golang.org/grpc"
+	// "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	// "google.golang.org/grpc/status"
+	"google.golang.org/grpc/testdata"
+	pb "github.com/serverlessresearch/srk/pkg/objstore"
+)
+
+var (
+	tls                = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
+	caFile             = flag.String("ca_file", "", "The file containing the CA root cert file")
+	serverAddr         = flag.String("server_addr", "127.0.0.1:10000", "The server address in the format of host:port")
+	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name use to verify the hostname returned by TLS handshake")
+	bucketName		   = flag.String("bucket_name", "/", "Object storage bucket name")
+)
+
+func createBucket(client pb.ObjectStoreClient, bucketName string) {
+	_, err := client.CreateBucket(context.Background(), &pb.CreateBucketRequest{BucketName: bucketName})
+	if err != nil {
+		log.Fatalf("%v.CreateBUcket(_) = _, %v: ", client, err)
+	}
+}
+
+func listBucket(client pb.ObjectStoreClient, bucketName string) {
+	listBucketResponse, err := client.ListBucket(context.Background(), &pb.ListBucketRequest{BucketName: bucketName})
+	if err != nil {
+		log.Fatalf("%v.ListBUcket(_) = _, %v: ", client, err)
+	} else {
+		for _, objectName := range listBucketResponse.GetObjectName() {
+			println(objectName)
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+	var opts []grpc.DialOption
+	if *tls {
+		if *caFile == "" {
+			*caFile = testdata.Path("ca.pem")
+		}
+		creds, err := credentials.NewClientTLSFromFile(*caFile, *serverHostOverride)
+		if err != nil {
+			log.Fatalf("Failed to create TLS credentials %v", err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
+	}
+	conn, err := grpc.Dial(*serverAddr, opts...)
+	if err != nil {
+		log.Fatalf("fail to dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewObjectStoreClient(conn)
+
+	createBucket(client, *bucketName)
+	listBucket(client, *bucketName)
+}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"io/ioutil"
 	"google.golang.org/grpc"
 	// "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -18,24 +19,48 @@ var (
 	serverAddr         = flag.String("server_addr", "127.0.0.1:10000", "The server address in the format of host:port")
 	serverHostOverride = flag.String("server_host_override", "x.test.youtube.com", "The server name use to verify the hostname returned by TLS handshake")
 	bucketName		   = flag.String("bucket_name", "/", "Object storage bucket name")
+	objectName		   = flag.String("object_name", "test.obj", "object storage object name")
 )
 
 func createBucket(client pb.ObjectStoreClient, bucketName string) {
 	_, err := client.CreateBucket(context.Background(), &pb.CreateBucketRequest{BucketName: bucketName})
 	if err != nil {
-		log.Fatalf("%v.CreateBUcket(_) = _, %v: ", client, err)
+		log.Fatalf("%v.CreateBucket(_) = _, %v: ", client, err)
 	}
 }
 
 func listBucket(client pb.ObjectStoreClient, bucketName string) {
-	listBucketResponse, err := client.ListBucket(context.Background(), &pb.ListBucketRequest{BucketName: bucketName})
+	res, err := client.ListBucket(context.Background(), &pb.ListBucketRequest{BucketName: bucketName})
 	if err != nil {
-		log.Fatalf("%v.ListBUcket(_) = _, %v: ", client, err)
+		log.Fatalf("%v.ListBucket(_) = _, %v: ", client, err)
 	} else {
-		for _, objectName := range listBucketResponse.GetObjectName() {
+		for _, objectName := range res.GetObjectName() {
 			println(objectName)
 		}
 	}
+}
+
+func getObject(client pb.ObjectStoreClient, bucketName string, objectName string) ([]byte) {
+	res, err := client.Get(context.Background(), &pb.GetRequest{ BucketName: bucketName, ObjectName: objectName})
+	if err != nil {
+		log.Fatalf("%v.Get(_) = _, %v: ", client, err)
+	}
+	return res.GetData()
+}
+
+func putObject(client pb.ObjectStoreClient, bucketName string, objectName string, data []byte) {
+	_, err := client.Put(context.Background(), &pb.PutRequest{ BucketName: bucketName, ObjectName: objectName, Data: data })
+	if err != nil {
+		log.Fatalf("%v.Put(_) = _, %v: ", client, err)
+	}
+}
+
+func uploadFile(client pb.ObjectStoreClient, bucketName string, objectName string, filepath string) {
+	data, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		log.Fatalf("Fail to read file %v: %v: ", filepath, err)
+	}
+	putObject(client, bucketName, objectName, data)
 }
 
 func main() {
@@ -60,6 +85,11 @@ func main() {
 	defer conn.Close()
 	client := pb.NewObjectStoreClient(conn)
 
+	testString := "Test测试" // word "test" in English and Chinese
 	createBucket(client, *bucketName)
 	listBucket(client, *bucketName)
+	putObject(client, *bucketName, *objectName, []byte(testString))
+	println("put string: ", testString)
+	data := getObject(client, *bucketName, *objectName)
+	println("get string: ", string(data))
 }

--- a/cmd/localobjstore/localobjstore.go
+++ b/cmd/localobjstore/localobjstore.go
@@ -5,9 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"google.golang.org/grpc"
-	// "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	// "google.golang.org/grpc/status"
 	"google.golang.org/grpc/testdata"
 	pb "github.com/serverlessresearch/srk/pkg/objstore"
 	"io/ioutil"
@@ -31,6 +29,7 @@ var (
 func (o *localObjStore) CreateBucket(ctx context.Context, r *pb.CreateBucketRequest) (*pb.Empty, error) {
 	err := os.Mkdir(path.Join(o.storageDir, r.GetBucketName()), 0755)
 	if err != nil {
+		// TODO: is this the right way to return error messages over gRPC?
 		return nil, err
 	}
 	return &pb.Empty{}, nil
@@ -49,11 +48,11 @@ func (o *localObjStore) ListBucket(ctx context.Context, r *pb.ListBucketRequest)
 }
 
 func (o *localObjStore) Get(ctx context.Context, r *pb.GetRequest) (*pb.GetResponse, error) {
-	dat, err := ioutil.ReadFile(path.Join(o.storageDir, r.GetBucketName(), r.GetObjectName())) 
+	data, err := ioutil.ReadFile(path.Join(o.storageDir, r.GetBucketName(), r.GetObjectName()))
 	if err != nil {
 		return nil, err
 	}
-	return &pb.GetResponse{ Data: dat }, nil
+	return &pb.GetResponse{ Data: data}, nil
 }
 
 func (o *localObjStore) Put(ctx context.Context, r *pb.PutRequest) (*pb.Empty, error) {

--- a/cmd/localobjstore/localobjstore.go
+++ b/cmd/localobjstore/localobjstore.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/testdata"
+	pb "github.com/serverlessresearch/srk/pkg/objstore"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"path"
+)
+
+type localObjStore struct {
+	storageDir string
+}
+
+var (
+	tls        = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
+	certFile   = flag.String("cert_file", "", "The TLS cert file")
+	keyFile    = flag.String("key_file", "", "The TLS key file")
+	port       = flag.Int("port", 10000, "The server port")
+)
+
+func (o *localObjStore) CreateBucket(ctx context.Context, r *pb.CreateBucketRequest) (*pb.Empty, error) {
+	err := os.Mkdir(path.Join(o.storageDir, r.BucketName), 0755)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.Empty{}, nil
+}
+
+func (o *localObjStore) ListBucket(ctx context.Context, r *pb.ListBucketRequest) (*pb.ListBucketResponse, error) {
+	files, err := ioutil.ReadDir(path.Join(o.storageDir, r.BucketName))
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(files))
+	for i := 0; i < len(files); i++ {
+		names[i] = files[i].Name()
+	}
+	return &pb.ListBucketResponse{ObjectName:names}, nil
+}
+
+
+func newServer(storageDir string) *pb.ObjectStoreServer {
+	s := &localObjStore{storageDir:storageDir}
+	return s
+}
+
+func main() {
+	flag.Parse()
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	fmt.Printf("Listening on port %d\n", *port)
+	var opts []grpc.ServerOption
+	if *tls {
+		if *certFile == "" {
+			*certFile = testdata.Path("server1.pem")
+		}
+		if *keyFile == "" {
+			*keyFile = testdata.Path("server1.key")
+		}
+		creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
+		if err != nil {
+			log.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+	pb.RegisterObjectStoreServer(grpcServer, newServer("/tmp/objfiles"))
+	grpcServer.Serve(lis)
+}

--- a/cmd/localobjstore/localobjstore.go
+++ b/cmd/localobjstore/localobjstore.go
@@ -5,9 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
+	// "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/status"
+	// "google.golang.org/grpc/status"
 	"google.golang.org/grpc/testdata"
 	pb "github.com/serverlessresearch/srk/pkg/objstore"
 	"io/ioutil"
@@ -49,8 +49,8 @@ func (o *localObjStore) ListBucket(ctx context.Context, r *pb.ListBucketRequest)
 }
 
 
-func newServer(storageDir string) *pb.ObjectStoreServer {
-	s := &localObjStore{storageDir:storageDir}
+func newServer(storageDir string) *localObjStore {
+	s := &localObjStore{storageDir: storageDir}
 	return s
 }
 

--- a/cmd/localobjstore/localobjstore.go
+++ b/cmd/localobjstore/localobjstore.go
@@ -29,7 +29,7 @@ var (
 )
 
 func (o *localObjStore) CreateBucket(ctx context.Context, r *pb.CreateBucketRequest) (*pb.Empty, error) {
-	err := os.Mkdir(path.Join(o.storageDir, r.BucketName), 0755)
+	err := os.Mkdir(path.Join(o.storageDir, r.GetBucketName()), 0755)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (o *localObjStore) CreateBucket(ctx context.Context, r *pb.CreateBucketRequ
 }
 
 func (o *localObjStore) ListBucket(ctx context.Context, r *pb.ListBucketRequest) (*pb.ListBucketResponse, error) {
-	files, err := ioutil.ReadDir(path.Join(o.storageDir, r.BucketName))
+	files, err := ioutil.ReadDir(path.Join(o.storageDir, r.GetBucketName()))
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +48,21 @@ func (o *localObjStore) ListBucket(ctx context.Context, r *pb.ListBucketRequest)
 	return &pb.ListBucketResponse{ObjectName:names}, nil
 }
 
+func (o *localObjStore) Get(ctx context.Context, r *pb.GetRequest) (*pb.GetResponse, error) {
+	dat, err := ioutil.ReadFile(path.Join(o.storageDir, r.GetBucketName(), r.GetObjectName())) 
+	if err != nil {
+		return nil, err
+	}
+	return &pb.GetResponse{ Data: dat }, nil
+}
+
+func (o *localObjStore) Put(ctx context.Context, r *pb.PutRequest) (*pb.Empty, error) {
+	err := ioutil.WriteFile(path.Join(o.storageDir, r.GetBucketName(), r.GetObjectName()), r.GetData(), 0644) 
+	if err != nil {
+		return nil, err
+	}
+	return &pb.Empty{}, nil
+}
 
 func newServer(storageDir string) *localObjStore {
 	s := &localObjStore{storageDir: storageDir}

--- a/pkg/objstore/objstore.proto
+++ b/pkg/objstore/objstore.proto
@@ -40,13 +40,13 @@ message GetRequest {
 }
 
 message GetResponse {
-    bytes object = 1;
+    bytes data = 1;
 }
 
 message PutRequest {
     string bucketName = 1;
     string objectName = 2;
-    bytes object = 3;
+    bytes data = 3;
 }
 
 message Empty {}

--- a/pkg/objstore/objstore.proto
+++ b/pkg/objstore/objstore.proto
@@ -15,9 +15,8 @@ package objstore;
 service ObjectStore {
     rpc createBucket(CreateBucketRequest) returns (Empty) {}
     rpc ListBucket(ListBucketRequest) returns (ListBucketResponse) {}
-//    rpc get(GetRequest) returns GetResponse {}
-//    rpc put(PutRequest) returns PutResponse {}
-//    rpc listBucket() returns
+    rpc get(GetRequest) returns (GetResponse) {}
+    rpc put(PutRequest) returns (PutResponse) {}
 //    rpc deleteBucket
 }
 
@@ -33,6 +32,25 @@ message ListBucketRequest {
 
 message ListBucketResponse {
     repeated string objectName = 1;
+}
+
+message GetRequest {
+    string bucketName = 1;
+    string objectName = 2;
+}
+
+message GetResponse {
+    bytes object = 1;
+}
+
+message PutRequest {
+    string bucketName = 1;
+    string objectName = 2;
+    bytes object = 3;
+}
+
+message PutResponse {
+    bytes object = 1;
 }
 
 message Empty {}

--- a/pkg/objstore/objstore.proto
+++ b/pkg/objstore/objstore.proto
@@ -16,7 +16,7 @@ service ObjectStore {
     rpc createBucket(CreateBucketRequest) returns (Empty) {}
     rpc ListBucket(ListBucketRequest) returns (ListBucketResponse) {}
     rpc get(GetRequest) returns (GetResponse) {}
-    rpc put(PutRequest) returns (PutResponse) {}
+    rpc put(PutRequest) returns (Empty) {}
 //    rpc deleteBucket
 }
 
@@ -47,10 +47,6 @@ message PutRequest {
     string bucketName = 1;
     string objectName = 2;
     bytes object = 3;
-}
-
-message PutResponse {
-    bytes object = 1;
 }
 
 message Empty {}

--- a/pkg/objstore/objstore.proto
+++ b/pkg/objstore/objstore.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package objstore;
+
+/* Design questions
+  - Do we want to be able to upload only part of an object
+  - What are we doing for permissions / ACLs
+  - What do we want to do for location, e.g., regions?
+  - How do object versions work?
+  - What concurrency models / consistency guarantees do we support
+  - How are we encoding error codes? Can we use standard rRPC status (https://github.com/grpc/grpc/blob/master/doc/statuscodes.md)
+*/
+
+
+service ObjectStore {
+    rpc createBucket(CreateBucketRequest) returns (Empty) {}
+    rpc ListBucket(ListBucketRequest) returns (ListBucketResponse) {}
+//    rpc get(GetRequest) returns GetResponse {}
+//    rpc put(PutRequest) returns PutResponse {}
+//    rpc listBucket() returns
+//    rpc deleteBucket
+}
+
+message CreateBucketRequest {
+    string bucketName = 1;
+    // TODO add permissions
+    // TODO add location
+}
+
+message ListBucketRequest {
+    string bucketName = 1;
+}
+
+message ListBucketResponse {
+    repeated string objectName = 1;
+}
+
+message Empty {}

--- a/pkg/objstore/objstore.proto
+++ b/pkg/objstore/objstore.proto
@@ -13,11 +13,11 @@ package objstore;
 
 
 service ObjectStore {
-    rpc createBucket(CreateBucketRequest) returns (Empty) {}
-    rpc ListBucket(ListBucketRequest) returns (ListBucketResponse) {}
-    rpc get(GetRequest) returns (GetResponse) {}
-    rpc put(PutRequest) returns (Empty) {}
-//    rpc deleteBucket
+    rpc createBucket (CreateBucketRequest) returns (Empty) {}
+    rpc listBucket (ListBucketRequest) returns (ListBucketResponse) {}
+    rpc get (GetRequest) returns (GetResponse) {}
+    rpc put (PutRequest) returns (Empty) {}
+    //    rpc deleteBucket
 }
 
 message CreateBucketRequest {


### PR DESCRIPTION
We are moving forward with a prototype object storage API implementation using gRPC as the transport. What's important about this contribution is the interface, not the implementation. What's most important to review is the gRPC file: `pkg/objstore/objstore.proto`.

Some notes:
- This implementation is all Go and uses a local file system to store the objects. We are using this to get the interface right, then will do a C++ implementation wrapping Anna.
- gRPC has greater latency than Thrift, however it is better suited to streaming large objects. See [experience at Alluxio](https://dzone.com/articles/moving-from-apache-thrift-to-grpc-a-perspective-fr)

Some key questions:
- How should object versions work?
- Do we want to be support multi-part object uploads?
- What are we doing for permissions / ACLs?
- What do we want to do for location, e.g., regions?
- What concurrency models / consistency guarantees do we support? Are such guarantees part of the interface / spec or not?
  - How are we encoding error codes? Can we use [standard gRPC status](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) or should we encode our own errors on top of gRPC?
- Should we be checking in the Go code generated by `protoc`? That would make builds simpler by eliminating a dependency?

  
