### PR TITLE
Use go module for this project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,26 @@ It aims to make it easy to innovate on services typically offered by cloud provi
 readily hackable versions of cloud functions or cloud object storage. SRK also plans to include common benchmarks
 and operational tools, so that launching and evaluating a multi-tenant serverless service is quick and easy.
 
-## Build
-To build this project, just run:
+## Build/Install
+This project is structured as a Go module, this means that it manages its own
+dependencies (via the go.mod and go.sum files) and does not need to be cloned
+into your GOPATH. To build this project, clone the repo anywhere you like and
+run:
 
   go build
 
 This will create the srk binary locally. To install to your GOPATH:
 
   go install
+
+For more details about Go modules, see this
+[post](https://github.com/golang/go/wiki/Modules).
+
+### Dependencies
+This project requires Go version 1.13 or greater.
+
+All Go package dependencies will be installed automatically when you run 'go
+build'.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ It aims to make it easy to innovate on services typically offered by cloud provi
 readily hackable versions of cloud functions or cloud object storage. SRK also plans to include common benchmarks
 and operational tools, so that launching and evaluating a multi-tenant serverless service is quick and easy.
 
+## Build
+To build this project, just run:
+
+  go build
+
+This will create the srk binary locally. To install to your GOPATH:
+
+  go install
+
 ## Examples
 
 ### Cloud Function Benchmark

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/serverlessresearch/srk
+
+go 1.13
+
+require github.com/aws/aws-sdk-go v1.23.18

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/aws/aws-sdk-go v1.23.18 h1:ADU/y1EO8yPzUJJYjcvJ0V9/suezxPh0u6hb5bSYIGQ=
+github.com/aws/aws-sdk-go v1.23.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
It allows us to build anywhere (no just in GOPATH) and adds versioning to dependencies. See
https://github.com/golang/go/wiki/Modules.

This is my first time trying this, but it mimics what openLambda does and it makes the project behave like any other github project where you can just clone and build. I'm not sure if it adds any extra-strict requirements (I see a 'go version 1.13' string in go.mod that might cause problems if anyone is using an older version).

It'd probably be a good idea to try this out on a few other machines to make sure it's not going to break anything.