### PR TITLE
Remove sudo from openlambda calls

### DIFF
--- a/pkg/openlambda/ol.go
+++ b/pkg/openlambda/ol.go
@@ -50,9 +50,8 @@ func (self *olConfig) Install(rawDir string) error {
 	tarPath := filepath.Clean(rawDir) + ".tar.gz"
 
 	installPath := filepath.Join(self.dir, "registry", filepath.Base(tarPath))
-	cmd := exec.Command("/bin/cp", tarPath, installPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return errors.Wrap(err, string(out))
+	if err := srk.CopyFile(tarPath, installPath); err != nil {
+		return err
 	}
 	self.log.Info("Open Lambda function installed to: " + installPath)
 	return nil

--- a/pkg/srk/util.go
+++ b/pkg/srk/util.go
@@ -1,0 +1,37 @@
+package srk
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func CopyFile(src, dst string) error {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", src)
+	}
+
+	from, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer from.Close()
+
+	to, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, sourceFileStat.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer to.Close()
+
+	_, err = io.Copy(to, from)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Requires the sudo-less fork of openlambda to work. I think more generally we are going to want to restrict ourselves to the fork so that we can do other things (like adding more stats).