### PR TITLE
Stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pdf
 log.txt
 build/
+*.swp

--- a/pkg/aws-lambda/awslambda.go
+++ b/pkg/aws-lambda/awslambda.go
@@ -43,6 +43,12 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 	return awsCfg, nil
 }
 
+func (self *awsLambdaConfig) ReportStats() (map[string]float64, error) {
+	stats := make(map[string]float64)
+
+	return stats, nil
+}
+
 func (self *awsLambdaConfig) Package(rawDir string) (zipDir string, rerr error) {
 	zipPath := filepath.Clean(rawDir) + ".zip"
 	rerr = zipRaw(rawDir, zipPath)

--- a/pkg/aws-lambda/awslambda.go
+++ b/pkg/aws-lambda/awslambda.go
@@ -43,7 +43,7 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 	return awsCfg, nil
 }
 
-func (self *awsLambdaConfig) ReportStats() (map[string]float64, error) {
+func (self *awsLambdaConfig) ReportStats(reset bool) (map[string]float64, error) {
 	stats := make(map[string]float64)
 
 	return stats, nil

--- a/pkg/aws-lambda/awslambda.go
+++ b/pkg/aws-lambda/awslambda.go
@@ -43,10 +43,15 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 	return awsCfg, nil
 }
 
-func (self *awsLambdaConfig) ReportStats(reset bool) (map[string]float64, error) {
+func (self *awsLambdaConfig) ReportStats() (map[string]float64, error) {
 	stats := make(map[string]float64)
 
 	return stats, nil
+}
+
+func (self *awsLambdaConfig) ResetStats() error {
+	// Nothing to reset yet
+	return nil
 }
 
 func (self *awsLambdaConfig) Package(rawDir string) (zipDir string, rerr error) {

--- a/pkg/cfbench/oneshot.go
+++ b/pkg/cfbench/oneshot.go
@@ -27,9 +27,13 @@ func (self *oneShotBench) RunBench(prov *srk.Provider, args *srk.BenchArgs) erro
 		return errors.Wrap(err, "Failed to invoke function "+args.FName+"("+args.FArgs+")")
 	}
 
-	stats, err := prov.Faas.ReportStats(true)
+	stats, err := prov.Faas.ReportStats()
 	if err != nil {
 		return errors.Wrap(err, "Failed to gather statistics about function "+args.FName+"("+args.FArgs+")")
+	}
+
+	if err = prov.Faas.ResetStats(); err != nil {
+		return errors.Wrap(err, "Failed to reset statistics for function "+args.FName+"("+args.FArgs+")")
 	}
 
 	self.log.Infof("Invocation statistics: \n")

--- a/pkg/cfbench/oneshot.go
+++ b/pkg/cfbench/oneshot.go
@@ -27,6 +27,16 @@ func (self *oneShotBench) RunBench(prov *srk.Provider, args *srk.BenchArgs) erro
 		return errors.Wrap(err, "Failed to invoke function "+args.FName+"("+args.FArgs+")")
 	}
 
+	stats, err := prov.Faas.ReportStats(true)
+	if err != nil {
+		return errors.Wrap(err, "Failed to gather statistics about function "+args.FName+"("+args.FArgs+")")
+	}
+
+	self.log.Infof("Invocation statistics: \n")
+	for k, v := range stats {
+		self.log.Infof("%s:\t%v\n", k, v)
+	}
+
 	time := time.Since(start)
 	self.log.Infof("Function Complete. Took %v\n", time)
 	self.log.Infof("Function Response:\n%v\n", resp)

--- a/pkg/openlambda/ol.go
+++ b/pkg/openlambda/ol.go
@@ -5,18 +5,26 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/serverlessresearch/srk/pkg/srk"
 	"github.com/spf13/viper"
 )
+
+type olStats struct {
+	tInvoke float64
+	nInvoke int
+}
 
 type olConfig struct {
 	// Command to run base openlambda manager ('ol')
@@ -32,6 +40,7 @@ type olConfig struct {
 	// Keeps track of if we've started an ol worker or not
 	sessionStarted bool
 	log            srk.Logger
+	stats          olStats
 }
 
 func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, error) {
@@ -53,8 +62,53 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 		isLocal:        isLocal,
 		sessionStarted: false,
 		log:            logger,
+		stats:          olStats{0, 0},
 	}
 	return olCfg, nil
+}
+
+func (self *olConfig) ReportStats() (map[string]float64, error) {
+
+	if !self.sessionStarted {
+		return nil, errors.New("No active OpenLambda sessions")
+	}
+
+	olResp, err := http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader(""))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to POST stats request to ol worker")
+	}
+
+	respBuf, err := ioutil.ReadAll(olResp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read stats response")
+	}
+
+	stats := make(map[string]float64)
+
+	var rawDecoded interface{}
+	if err = json.Unmarshal(respBuf, &rawDecoded); err != nil {
+		return nil, errors.Wrap(err, "Failed to interpret OL statistics")
+	}
+
+	decoded := rawDecoded.(map[string]interface{})
+	for k, v := range decoded {
+		if floatv, ok := v.(float64); ok {
+			stats[k] = floatv
+		} else {
+			self.log.Warnf("Ignoring non-numeric statistics result from openLambda: %v=%v", k, v)
+		}
+	}
+	stats["srkInvoke"] = self.stats.tInvoke / float64(self.stats.nInvoke)
+
+	//Reset the statistics
+	_, err = http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader("reset"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to reset stats on ol worker")
+	}
+	self.stats.tInvoke = 0
+	self.stats.nInvoke = 0
+
+	return stats, nil
 }
 
 func (self *olConfig) Package(rawDir string) (string, error) {
@@ -115,12 +169,15 @@ func (self *olConfig) Invoke(fName string, args string) (resp *bytes.Buffer, rer
 	// Round-robin between servers
 	urlx := atomic.AddUint64(&self.lastUrl, 1) % uint64(len(self.urls))
 	url := self.urls[urlx]
+	start := time.Now()
 	olResp, err := http.Post(url+"/run/"+fName, "application/json", strings.NewReader(args))
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to POST request to ol worker")
 	}
 	respBuf := new(bytes.Buffer)
 	respBuf.ReadFrom(olResp.Body)
+	self.stats.tInvoke += float64(time.Since(start).Microseconds())
+	self.stats.nInvoke++
 
 	return respBuf, nil
 }

--- a/pkg/openlambda/ol.go
+++ b/pkg/openlambda/ol.go
@@ -67,7 +67,7 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 	return olCfg, nil
 }
 
-func (self *olConfig) ReportStats(reset bool) (map[string]float64, error) {
+func (self *olConfig) ReportStats() (map[string]float64, error) {
 
 	if !self.sessionStarted {
 		return nil, errors.New("No active OpenLambda sessions")
@@ -100,17 +100,18 @@ func (self *olConfig) ReportStats(reset bool) (map[string]float64, error) {
 	}
 	stats["srkInvoke"] = self.stats.tInvoke / float64(self.stats.nInvoke)
 
-	if reset {
-		//Reset the statistics
-		_, err = http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader("reset"))
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to reset stats on ol worker")
-		}
-		self.stats.tInvoke = 0
-		self.stats.nInvoke = 0
-	}
-
 	return stats, nil
+}
+
+func (self *olConfig) ResetStats() error {
+	//Reset the statistics
+	_, err := http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader("reset"))
+	if err != nil {
+		return err
+	}
+	self.stats.tInvoke = 0
+	self.stats.nInvoke = 0
+	return nil
 }
 
 func (self *olConfig) Package(rawDir string) (string, error) {

--- a/pkg/openlambda/ol.go
+++ b/pkg/openlambda/ol.go
@@ -67,7 +67,7 @@ func NewConfig(logger srk.Logger, config *viper.Viper) (srk.FunctionService, err
 	return olCfg, nil
 }
 
-func (self *olConfig) ReportStats() (map[string]float64, error) {
+func (self *olConfig) ReportStats(reset bool) (map[string]float64, error) {
 
 	if !self.sessionStarted {
 		return nil, errors.New("No active OpenLambda sessions")
@@ -100,13 +100,15 @@ func (self *olConfig) ReportStats() (map[string]float64, error) {
 	}
 	stats["srkInvoke"] = self.stats.tInvoke / float64(self.stats.nInvoke)
 
-	//Reset the statistics
-	_, err = http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader("reset"))
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to reset stats on ol worker")
+	if reset {
+		//Reset the statistics
+		_, err = http.Post(self.urls[0]+"/stats", "application/json", strings.NewReader("reset"))
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to reset stats on ol worker")
+		}
+		self.stats.tInvoke = 0
+		self.stats.nInvoke = 0
 	}
-	self.stats.tInvoke = 0
-	self.stats.nInvoke = 0
 
 	return stats, nil
 }

--- a/pkg/srk/interface.go
+++ b/pkg/srk/interface.go
@@ -21,6 +21,7 @@ type Provider struct {
 // All new function services should provide an object that meets this interface, with a constructor like:
 // func NewConfig(logger Logger, config *viper.Viper) (FunctionService, error)
 type FunctionService interface {
+
 	// Package up everything needed to install the function but don't actually
 	// install it to the service. rawDir may be assumed to be a unique path for
 	// this function. The package location should be determinsitically derived
@@ -48,6 +49,11 @@ type FunctionService interface {
 	// Failure to destroy may leave the system in an inconsistent state that
 	// requires manual intervention.
 	Destroy()
+
+	// Report any collected statistics for this service. The collected
+	// statistics are dependent on the underlying implementation (you should
+	// always check if an expected category is available before reading).
+	ReportStats() (map[string]float64, error)
 }
 
 type BenchArgs struct {

--- a/pkg/srk/interface.go
+++ b/pkg/srk/interface.go
@@ -53,9 +53,11 @@ type FunctionService interface {
 	// Report any collected statistics for this service. The collected
 	// statistics are dependent on the underlying implementation (you should
 	// always check if an expected category is available before reading).
-	// reset=True will reset statistics, False will report stats without
-	// changing them.
-	ReportStats(reset bool) (map[string]float64, error)
+	ReportStats() (map[string]float64, error)
+
+	// Resets all statistics to a 0 state. New calls to ReportStats() will only
+	// report new events.
+	ResetStats() error
 }
 
 type BenchArgs struct {

--- a/pkg/srk/interface.go
+++ b/pkg/srk/interface.go
@@ -53,7 +53,9 @@ type FunctionService interface {
 	// Report any collected statistics for this service. The collected
 	// statistics are dependent on the underlying implementation (you should
 	// always check if an expected category is available before reading).
-	ReportStats() (map[string]float64, error)
+	// reset=True will reset statistics, False will report stats without
+	// changing them.
+	ReportStats(reset bool) (map[string]float64, error)
 }
 
 type BenchArgs struct {

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+set -e
+
+# Hack to let us call this like ./tools/test.sh or "cd test; ./test.sh"
+if [ -f ../srk ]; then
+  cd ..
+fi
+
+echo "Rebuilding"
+go build
+
+echo "Create Func"
+./srk function create --source examples/echo
+
+echo "Run Bench"
+./srk bench \
+        --benchmark one-shot \
+        --function-args '{"hello" : "world"}' \
+        --function-name echo
+
+echo "Remove Func"
+./srk function remove -n echo


### PR DESCRIPTION
Adds global aggregate stats interface t FaaS interface. This is meant for coarse-grained stats collection about global behaviors. We will still need other mechanisms for detailed logging and/or tracing of individual calls.